### PR TITLE
Improve service worker cache invalidation

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,25 +1,85 @@
-const CACHE_NAME = "revi3-cache-v1";
-const urlsToCache = [
-	"/",
-	"/manifest.json",
-	"/css/app.css",
-	"/themes/default/css/custom.css",
-	"/js/app.js",
-	"/images/theme/theme-favicon-logo.png",
-	"/images/theme/theme-logo.png",
+const CACHE_VERSION = "v2";
+const CACHE_NAME = `revi3-cache-${CACHE_VERSION}`;
+const APP_SHELL = [
+        "/",
+        "/manifest.json",
+        "/css/app.css",
+        "/themes/default/css/custom.css",
+        "/js/app.js",
+        "/images/theme/theme-favicon-logo.png",
+        "/images/theme/theme-logo.png",
 ];
+const NETWORK_ONLY_PATTERNS = [/\/api\//];
 
 self.addEventListener("install", (event) => {
-	event.waitUntil(
-		caches.open(CACHE_NAME).then((cache) => cache.addAll(urlsToCache))
-	);
-	self.skipWaiting();
+        event.waitUntil(
+                caches.open(CACHE_NAME).then((cache) => cache.addAll(APP_SHELL))
+        );
+        self.skipWaiting();
+});
+
+self.addEventListener("activate", (event) => {
+        event.waitUntil(
+                caches.keys().then((cacheNames) =>
+                        Promise.all(
+                                cacheNames
+                                        .filter((cacheName) => cacheName !== CACHE_NAME)
+                                        .map((cacheName) => caches.delete(cacheName))
+                        )
+                )
+        );
+        self.clients.claim();
 });
 
 self.addEventListener("fetch", (event) => {
-	event.respondWith(
-		caches
-			.match(event.request)
-			.then((response) => response || fetch(event.request))
-	);
+        if (event.request.method !== "GET") {
+                return;
+        }
+
+        const requestUrl = new URL(event.request.url);
+
+        if (NETWORK_ONLY_PATTERNS.some((pattern) => pattern.test(requestUrl.pathname))) {
+                return;
+        }
+
+        if (requestUrl.pathname === "/js/app.js" || requestUrl.pathname === "/css/app.css") {
+                event.respondWith(
+                        fetch(event.request)
+                                .then((response) => {
+                                        const responseClone = response.clone();
+                                        caches
+                                                .open(CACHE_NAME)
+                                                .then((cache) => cache.put(event.request, responseClone));
+                                        return response;
+                                })
+                                .catch(() => caches.match(event.request))
+                );
+                return;
+        }
+
+        event.respondWith(
+                caches.match(event.request).then((cachedResponse) => {
+                        if (cachedResponse) {
+                                return cachedResponse;
+                        }
+
+                        return fetch(event.request)
+                                .then((networkResponse) => {
+                                        if (
+                                                !networkResponse ||
+                                                networkResponse.status !== 200 ||
+                                                networkResponse.type !== "basic"
+                                        ) {
+                                                return networkResponse;
+                                        }
+
+                                        const responseClone = networkResponse.clone();
+                                        caches
+                                                .open(CACHE_NAME)
+                                                .then((cache) => cache.put(event.request, responseClone));
+                                        return networkResponse;
+                                })
+                                .catch(() => caches.match(event.request));
+                })
+        );
 });


### PR DESCRIPTION
## Summary
- version the service worker cache and clean old entries during activation so that updated assets are picked up after deploys
- add network-first handling for the main JS and CSS bundles and avoid caching API responses to keep table links current

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d3bfbb8ed08323925bfa0325ef2639